### PR TITLE
fix: posição logo scielo nos sponsors

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -4076,3 +4076,24 @@
 			margin-top: 0;
 			padding-top: 0;
 		}
+
+
+
+
+// logo de patrocinadores:
+.content.sponsors .sponsor {
+	height: 200px;      /* equals max image height */
+    width: 360px;		/* equals max image width */
+    white-space: nowrap;
+    display: inline;
+    text-align: center;
+    margin: 1em 0;
+	border: 1px solid red !important;
+}
+
+.content.sponsors img.sponsor-logo {
+	vertical-align: middle;
+	max-height: 200px;
+    max-width: 360px;
+
+}

--- a/index.html
+++ b/index.html
@@ -108,9 +108,12 @@
 										<header class="major">
 											<h2>Patrocínio Tutorial</h2>
 										</header>
-										<div class="content">
+										<div class="content sponsors">
 											<a href="https://avidity.com.br/">
-												<img src="images/logos/avidity.png" alt="Avidity" />
+												<img class="sponsor-logo" src="images/logos/avidity.png" alt="Avidity" />
+											</a>
+											<a href="http://www.scielo.org/php/index.php">
+												<img class="sponsor-logo" src="images/logos/scielo.png" alt="SciELO" />
 											</a>
 										</div>
 										<br/>
@@ -126,9 +129,6 @@
 										</header>
 										<div class="content">
 											<!-- 416 x 256 -->
-											<a href="http://www.scielo.org/php/index.php">
-												<img src="images/logos/scielo.png" alt="SciELO" />
-											</a>
 											<a href="http://associacao.python.org.br/">
 												<img src="images/logos/apyb.png" alt="Associação Python Brasil" />
 											</a>


### PR DESCRIPTION
## Descrição:

Ajuste de posicionamento dos logo da Scielo (antes na seção de "Apoio")  agora na seção de "Patrocinadores"

## Onde começar a revisar:

- index.html (seção de apoio/patrocínio tutorial)
- main.css (final do arquivo)

## O que deve ser revisado:
A seção e logo da scielo devem ser corretas

## Screenshots:

### no browser:
![screenshot 2018-07-24 14 39 43](https://user-images.githubusercontent.com/805749/43156620-30f52814-8f6a-11e8-8b90-dfeb5e96129d.png)

### no mobile (browser)
![screen shot 2018-07-24 at 14 44 07-fullpage](https://user-images.githubusercontent.com/805749/43156627-36c0e274-8f6a-11e8-92e3-454edc97d613.png)

## Observações:
**Não** modifiquei o arquivo sass: `assets/sass/main.scss` 
